### PR TITLE
WIP: Add zlib to build requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - remove_static_build_path.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
   detect_binary_files_with_prefix: True
 
@@ -29,6 +29,7 @@ requirements:
     - bison
     - flex
     - readline
+    - zlib
 
 test:
   commands:


### PR DESCRIPTION
This should enable support for LXT2
